### PR TITLE
fix(ci): Correct Docker container networking in test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,15 +258,14 @@ jobs:
         run: |
           set -e
           docker run -d -p 8080:8080 --name test-container \
-            --network host \
             -e JWT_SECRET=dGVzdCBzZWNyZXQgZm9yIHRlc3RpbmcgcHVycG9zZXMgb25seQ== \
             -e ADMIN_USERNAME=admin \
             -e ADMIN_PASSWORD=admin123 \
             -e FLYWAY_ENABLED=false \
-            -e DB_URL=r2dbc:postgresql://localhost:5432/testdb \
+            -e DB_URL=r2dbc:postgresql://postgres:5432/testdb \
             -e DB_USERNAME=testuser \
             -e DB_PASSWORD=testpass \
-            -e FLYWAY_URL=jdbc:postgresql://localhost:5432/testdb \
+            -e FLYWAY_URL=jdbc:postgresql://postgres:5432/testdb \
             ${{ secrets.DOCKER_USERNAME }}/employee-management-api:latest
           sleep 15
           if curl -f -u admin:admin123 http://localhost:8080/api/v1/employees; then


### PR DESCRIPTION
The Docker integration test was failing because the application container was using host networking and could not resolve the  service at .

This change removes the  flag and updates the database connection URL to use the service hostname . This allows the application and database containers to communicate correctly within the job.